### PR TITLE
Implement event processing skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# event_handler
+# Event Handler
+
+This repository provides a minimal implementation of an event processing center as described in the software requirements specification.  
+The `EventProcessor` routes incoming events to registered handlers while coordinating supporting services.  Only a `DeploymentChangeHandler` is included as an example.
+
+## Running tests
+
+```
+pytest -q
+```

--- a/event_handler/__init__.py
+++ b/event_handler/__init__.py
@@ -1,0 +1,23 @@
+from .event import Event
+from .context import Context
+from .processor import EventProcessor
+from .handlers.deployment_change import DeploymentChangeHandler
+from .services.repository import Repository
+from .services.pressure_tester import PressureTester
+from .services.throughput_recorder import ThroughputRecorder
+from .services.adjustment_coordinator import AdjustmentCoordinator
+from .services.dispatcher import Dispatcher
+from .services.state_manager import StateManager
+
+__all__ = [
+    "Event",
+    "Context",
+    "EventProcessor",
+    "DeploymentChangeHandler",
+    "Repository",
+    "PressureTester",
+    "ThroughputRecorder",
+    "AdjustmentCoordinator",
+    "Dispatcher",
+    "StateManager",
+]

--- a/event_handler/context.py
+++ b/event_handler/context.py
@@ -1,0 +1,16 @@
+from typing import NamedTuple
+
+from .services.repository import Repository
+from .services.pressure_tester import PressureTester
+from .services.throughput_recorder import ThroughputRecorder
+from .services.adjustment_coordinator import AdjustmentCoordinator
+from .services.dispatcher import Dispatcher
+from .services.state_manager import StateManager
+
+class Context(NamedTuple):
+    repo: Repository
+    tester: PressureTester
+    recorder: ThroughputRecorder
+    adjuster: AdjustmentCoordinator
+    dispatcher: Dispatcher
+    state: StateManager

--- a/event_handler/event.py
+++ b/event_handler/event.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class Event:
+    type: str
+    payload: dict
+    timestamp: datetime
+    source: str

--- a/event_handler/handlers/__init__.py
+++ b/event_handler/handlers/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseHandler
+from .deployment_change import DeploymentChangeHandler
+
+__all__ = ["BaseHandler", "DeploymentChangeHandler"]

--- a/event_handler/handlers/base.py
+++ b/event_handler/handlers/base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+from ..event import Event
+from ..context import Context
+
+class BaseHandler(ABC):
+    @abstractmethod
+    async def handle(self, event: Event, ctx: Context) -> None:
+        """Process an event."""
+        raise NotImplementedError

--- a/event_handler/handlers/deployment_change.py
+++ b/event_handler/handlers/deployment_change.py
@@ -1,0 +1,15 @@
+from ..event import Event
+from ..context import Context
+from .base import BaseHandler
+
+class DeploymentChangeHandler(BaseHandler):
+    async def handle(self, event: Event, ctx: Context) -> None:
+        deployment_hash = event.payload.get("hash")
+        if deployment_hash is None:
+            return
+        throughput = await ctx.recorder.get(deployment_hash)
+        if throughput is None:
+            throughput = await ctx.tester.load_test(deployment_hash)
+            await ctx.recorder.save(deployment_hash, throughput)
+        frequency = await ctx.adjuster.compute_frequency(throughput)
+        await ctx.dispatcher.dispatch(frequency)

--- a/event_handler/processor.py
+++ b/event_handler/processor.py
@@ -1,0 +1,26 @@
+from typing import Dict
+
+from .event import Event
+from .context import Context
+from .services.state_manager import State
+from .handlers.base import BaseHandler
+
+class EventProcessor:
+    def __init__(self, ctx: Context):
+        self.ctx = ctx
+        self.handlers: Dict[str, BaseHandler] = {}
+
+    def register_handler(self, event_type: str, handler: BaseHandler) -> None:
+        self.handlers[event_type] = handler
+
+    async def process(self, event: Event) -> None:
+        handler = self.handlers.get(event.type)
+        if not handler:
+            return
+        entered = await self.ctx.state.try_enter_adjusting()
+        if not entered:
+            return
+        try:
+            await handler.handle(event, self.ctx)
+        finally:
+            await self.ctx.state.exit_adjusting()

--- a/event_handler/services/__init__.py
+++ b/event_handler/services/__init__.py
@@ -1,0 +1,16 @@
+from .repository import Repository
+from .pressure_tester import PressureTester
+from .throughput_recorder import ThroughputRecorder
+from .adjustment_coordinator import AdjustmentCoordinator
+from .dispatcher import Dispatcher
+from .state_manager import StateManager, State
+
+__all__ = [
+    "Repository",
+    "PressureTester",
+    "ThroughputRecorder",
+    "AdjustmentCoordinator",
+    "Dispatcher",
+    "StateManager",
+    "State",
+]

--- a/event_handler/services/adjustment_coordinator.py
+++ b/event_handler/services/adjustment_coordinator.py
@@ -1,0 +1,6 @@
+class AdjustmentCoordinator:
+    """Compute new request frequency."""
+
+    async def compute_frequency(self, throughput: int) -> int:
+        # Simple identity mapping for now
+        return throughput

--- a/event_handler/services/dispatcher.py
+++ b/event_handler/services/dispatcher.py
@@ -1,0 +1,9 @@
+class Dispatcher:
+    """Send commands to external agents."""
+
+    def __init__(self):
+        self.last_dispatched = None
+
+    async def dispatch(self, frequency: int) -> None:
+        # Just store the frequency for tests
+        self.last_dispatched = frequency

--- a/event_handler/services/pressure_tester.py
+++ b/event_handler/services/pressure_tester.py
@@ -1,0 +1,6 @@
+class PressureTester:
+    """Stub that 'measures' throughput."""
+
+    async def load_test(self, deployment_hash: str) -> int:
+        # In real impl, run load test. Here return fixed value.
+        return 100

--- a/event_handler/services/repository.py
+++ b/event_handler/services/repository.py
@@ -1,0 +1,11 @@
+class Repository:
+    """Simple in-memory repository placeholder."""
+
+    def __init__(self):
+        self.storage = {}
+
+    async def get(self, key):
+        return self.storage.get(key)
+
+    async def set(self, key, value):
+        self.storage[key] = value

--- a/event_handler/services/state_manager.py
+++ b/event_handler/services/state_manager.py
@@ -1,0 +1,22 @@
+import asyncio
+from enum import Enum
+
+class State(Enum):
+    STABLE = "stable"
+    ADJUSTING = "adjusting"
+
+class StateManager:
+    def __init__(self):
+        self.state = State.STABLE
+        self._lock = asyncio.Lock()
+
+    async def try_enter_adjusting(self) -> bool:
+        async with self._lock:
+            if self.state == State.ADJUSTING:
+                return False
+            self.state = State.ADJUSTING
+            return True
+
+    async def exit_adjusting(self) -> None:
+        async with self._lock:
+            self.state = State.STABLE

--- a/event_handler/services/throughput_recorder.py
+++ b/event_handler/services/throughput_recorder.py
@@ -1,0 +1,11 @@
+class ThroughputRecorder:
+    """In-memory store for throughput values."""
+
+    def __init__(self):
+        self._values = {}
+
+    async def get(self, deployment_hash: str):
+        return self._values.get(deployment_hash)
+
+    async def save(self, deployment_hash: str, throughput: int) -> None:
+        self._values[deployment_hash] = throughput

--- a/tests/test_deployment_change.py
+++ b/tests/test_deployment_change.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+import asyncio
+
+from event_handler import (
+    Event,
+    Context,
+    EventProcessor,
+    DeploymentChangeHandler,
+    Repository,
+    PressureTester,
+    ThroughputRecorder,
+    AdjustmentCoordinator,
+    Dispatcher,
+    StateManager,
+)
+
+
+def test_deployment_change_flow():
+    async def run():
+        repo = Repository()
+        tester = PressureTester()
+        recorder = ThroughputRecorder()
+        adjuster = AdjustmentCoordinator()
+        dispatcher = Dispatcher()
+        state = StateManager()
+
+        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state)
+        processor = EventProcessor(ctx)
+        processor.register_handler("DEPLOYMENT_CHANGE", DeploymentChangeHandler())
+
+        event = Event(
+            type="DEPLOYMENT_CHANGE",
+            payload={"hash": "abc"},
+            timestamp=datetime.utcnow(),
+            source="detector",
+        )
+
+        await processor.process(event)
+
+        assert dispatcher.last_dispatched == 100
+        assert await recorder.get("abc") == 100
+        assert state.state.value == "stable"
+
+        # Second run should not invoke load test again
+        await processor.process(event)
+        assert dispatcher.last_dispatched == 100
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add dataclasses and base interfaces for `Event`, `BaseHandler`, and `Context`
- implement minimal `EventProcessor` with handler registry and state machine
- include stub services and a `DeploymentChangeHandler`
- provide tests demonstrating deployment-change workflow
- update README with instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd66fd4808331a8e0776f03a2c0e5