### PR TITLE
Add skeleton event handlers for high latency and idle system

### DIFF
--- a/event_handler/__init__.py
+++ b/event_handler/__init__.py
@@ -2,6 +2,8 @@ from .event import Event
 from .context import Context
 from .processor import EventProcessor
 from .handlers.deployment_change import DeploymentChangeHandler
+from .handlers.high_latency import HighLatencyHandler
+from .handlers.idle_system import IdleSystemHandler
 from .services.repository import Repository
 from .services.pressure_tester import PressureTester
 from .services.throughput_recorder import ThroughputRecorder
@@ -14,6 +16,8 @@ __all__ = [
     "Context",
     "EventProcessor",
     "DeploymentChangeHandler",
+    "HighLatencyHandler",
+    "IdleSystemHandler",
     "Repository",
     "PressureTester",
     "ThroughputRecorder",

--- a/event_handler/handlers/__init__.py
+++ b/event_handler/handlers/__init__.py
@@ -1,4 +1,11 @@
 from .base import BaseHandler
 from .deployment_change import DeploymentChangeHandler
+from .high_latency import HighLatencyHandler
+from .idle_system import IdleSystemHandler
 
-__all__ = ["BaseHandler", "DeploymentChangeHandler"]
+__all__ = [
+    "BaseHandler",
+    "DeploymentChangeHandler",
+    "HighLatencyHandler",
+    "IdleSystemHandler",
+]

--- a/event_handler/handlers/high_latency.py
+++ b/event_handler/handlers/high_latency.py
@@ -1,0 +1,12 @@
+from ..event import Event
+from ..context import Context
+from .base import BaseHandler
+
+
+class HighLatencyHandler(BaseHandler):
+    """Handle high latency events."""
+
+    async def handle(self, event: Event, ctx: Context) -> None:
+        """Placeholder implementation."""
+        # Real logic will decrease frequency and schedule retest
+        pass

--- a/event_handler/handlers/idle_system.py
+++ b/event_handler/handlers/idle_system.py
@@ -1,0 +1,12 @@
+from ..event import Event
+from ..context import Context
+from .base import BaseHandler
+
+
+class IdleSystemHandler(BaseHandler):
+    """Handle idle system events."""
+
+    async def handle(self, event: Event, ctx: Context) -> None:
+        """Placeholder implementation."""
+        # Real logic will reduce or pause frequency
+        pass

--- a/tests/test_high_latency.py
+++ b/tests/test_high_latency.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+import asyncio
+
+from event_handler import (
+    Event,
+    Context,
+    EventProcessor,
+    HighLatencyHandler,
+    Repository,
+    PressureTester,
+    ThroughputRecorder,
+    AdjustmentCoordinator,
+    Dispatcher,
+    StateManager,
+)
+
+
+def test_high_latency_handler_registration():
+    called = False
+
+    class CustomHighLatencyHandler(HighLatencyHandler):
+        async def handle(self, event: Event, ctx: Context) -> None:
+            nonlocal called
+            called = True
+
+    async def run():
+        repo = Repository()
+        tester = PressureTester()
+        recorder = ThroughputRecorder()
+        adjuster = AdjustmentCoordinator()
+        dispatcher = Dispatcher()
+        state = StateManager()
+        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state)
+        processor = EventProcessor(ctx)
+        processor.register_handler("HIGH_LATENCY", CustomHighLatencyHandler())
+
+        event = Event(
+            type="HIGH_LATENCY",
+            payload={"latency_ms": 500},
+            timestamp=datetime.utcnow(),
+            source="detector",
+        )
+
+        await processor.process(event)
+
+        assert called
+        assert state.state.value == "stable"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- provide HighLatencyHandler and IdleSystemHandler stubs
- export new handlers from package
- test that a high latency handler can be registered and invoked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df6d819488331b5afcb8a82855250