### PR TITLE
Add basic logging to handlers and tests

### DIFF
--- a/event_handler/handlers/deployment_change.py
+++ b/event_handler/handlers/deployment_change.py
@@ -1,15 +1,25 @@
+import logging
+
 from ..event import Event
 from ..context import Context
 from .base import BaseHandler
 
+logger = logging.getLogger(__name__)
+
 class DeploymentChangeHandler(BaseHandler):
     async def handle(self, event: Event, ctx: Context) -> None:
         deployment_hash = event.payload.get("hash")
+        logger.info("Deployment change event received: %s", deployment_hash)
         if deployment_hash is None:
+            logger.info("No deployment hash provided")
             return
         throughput = await ctx.recorder.get(deployment_hash)
+        logger.info("Throughput lookup result: %s", throughput)
         if throughput is None:
+            logger.info("Running load test for %s", deployment_hash)
             throughput = await ctx.tester.load_test(deployment_hash)
             await ctx.recorder.save(deployment_hash, throughput)
+            logger.info("Recorded throughput %s", throughput)
         frequency = await ctx.adjuster.compute_frequency(throughput)
         await ctx.dispatcher.dispatch(frequency)
+        logger.info("Dispatched frequency %s", frequency)

--- a/event_handler/handlers/high_latency.py
+++ b/event_handler/handlers/high_latency.py
@@ -1,6 +1,10 @@
+import logging
+
 from ..event import Event
 from ..context import Context
 from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
 
 
 class HighLatencyHandler(BaseHandler):
@@ -8,5 +12,6 @@ class HighLatencyHandler(BaseHandler):
 
     async def handle(self, event: Event, ctx: Context) -> None:
         """Placeholder implementation."""
+        logger.info("High latency event received: %s", event.payload)
         # Real logic will decrease frequency and schedule retest
-        pass
+        logger.info("No action taken in stub handler")

--- a/event_handler/handlers/idle_system.py
+++ b/event_handler/handlers/idle_system.py
@@ -1,6 +1,10 @@
+import logging
+
 from ..event import Event
 from ..context import Context
 from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
 
 
 class IdleSystemHandler(BaseHandler):
@@ -8,5 +12,6 @@ class IdleSystemHandler(BaseHandler):
 
     async def handle(self, event: Event, ctx: Context) -> None:
         """Placeholder implementation."""
+        logger.info("Idle system event received: %s", event.payload)
         # Real logic will reduce or pause frequency
-        pass
+        logger.info("No action taken in stub handler")

--- a/tests/test_deployment_change.py
+++ b/tests/test_deployment_change.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 import asyncio
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 from event_handler import (
     Event,
@@ -35,14 +38,18 @@ def test_deployment_change_flow():
             source="detector",
         )
 
+        logging.info("processing deployment change event")
         await processor.process(event)
+        logging.info("finished deployment change event")
 
         assert dispatcher.last_dispatched == 100
         assert await recorder.get("abc") == 100
         assert state.state.value == "stable"
 
         # Second run should not invoke load test again
+        logging.info("processing deployment change event again")
         await processor.process(event)
+        logging.info("finished second deployment change event")
         assert dispatcher.last_dispatched == 100
 
     asyncio.run(run())

--- a/tests/test_high_latency.py
+++ b/tests/test_high_latency.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 import asyncio
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 from event_handler import (
     Event,
@@ -41,7 +44,9 @@ def test_high_latency_handler_registration():
             source="detector",
         )
 
+        logging.info("processing high latency event")
         await processor.process(event)
+        logging.info("finished high latency event")
 
         assert called
         assert state.state.value == "stable"


### PR DESCRIPTION
## Summary
- enable INFO logging in test suites
- log before and after event processing in tests
- add informative logging to stub handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0eb779f483319187ebcb018e9d9e