### PR TITLE
Add nested JSON support in ThroughputRecorder

### DIFF
--- a/event_handler/services/throughput_recorder.py
+++ b/event_handler/services/throughput_recorder.py
@@ -1,11 +1,83 @@
+"""Utility for persisting and querying throughput data.
+
+The original implementation only kept an in-memory dictionary mapping a
+deployment hash to an integer throughput value.  Some tests still rely on that
+behaviour, but the recorder now also understands a more complex JSON structure
+where each key can contain sub categories (e.g. ``pose`` or ``gesture``) with a
+``throughput`` field.  An example of the supported JSON format is::
+
+    {
+        "node1:gesture=2,pose=1": {
+            "pose": {"throughput": 20},
+            "gesture": {"throughput": 30}
+        },
+        "node2:object=1,pose=1": {
+            "pose": {"throughput": 40},
+            "object": {"throughput": 15}
+        }
+    }
+
+When a ``file_path`` is provided, the recorder will load the JSON data from the
+file at initialisation time and persist updates back to the same file.
+``get`` and ``save`` accept an optional ``category`` argument for accessing the
+nested values.  When ``category`` is omitted the behaviour is backwards
+compatible with the original implementation and simply treats the value as a
+plain integer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
 class ThroughputRecorder:
-    """In-memory store for throughput values."""
+    """Persist and retrieve throughput values."""
 
-    def __init__(self):
-        self._values = {}
+    def __init__(self, *, initial_data: Optional[Dict[str, Any]] = None, file_path: Optional[str] = None) -> None:
+        self._values: Dict[str, Any] = initial_data.copy() if initial_data else {}
+        self._path: Optional[Path] = Path(file_path) if file_path else None
+        if self._path and self._path.exists():
+            try:
+                loaded = json.loads(self._path.read_text())
+                if isinstance(loaded, dict):
+                    self._values.update(loaded)
+            except json.JSONDecodeError:
+                # Invalid json, ignore and start fresh
+                pass
 
-    async def get(self, deployment_hash: str):
-        return self._values.get(deployment_hash)
+    async def get(self, key: str, category: Optional[str] = None) -> Optional[int]:
+        value = self._values.get(key)
+        if category is None:
+            if isinstance(value, dict):
+                # if the stored value has a single category, return its throughput
+                if len(value) == 1:
+                    inner = next(iter(value.values()))
+                    return inner.get("throughput") if isinstance(inner, dict) else None
+                return None
+            return value
+        if not isinstance(value, dict):
+            return None
+        inner = value.get(category)
+        if isinstance(inner, dict):
+            return inner.get("throughput")
+        return None
 
-    async def save(self, deployment_hash: str, throughput: int) -> None:
-        self._values[deployment_hash] = throughput
+    async def save(self, key: str, throughput: int, category: Optional[str] = None) -> None:
+        if category is None:
+            self._values[key] = throughput
+        else:
+            bucket = self._values.setdefault(key, {})
+            if not isinstance(bucket, dict):
+                bucket = {}
+                self._values[key] = bucket
+            entry = bucket.setdefault(category, {})
+            if not isinstance(entry, dict):
+                entry = {}
+                bucket[category] = entry
+            entry["throughput"] = throughput
+
+        if self._path:
+            self._path.write_text(json.dumps(self._values, indent=2))
+

--- a/tests/test_throughput_recorder.py
+++ b/tests/test_throughput_recorder.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from event_handler.services.throughput_recorder import ThroughputRecorder
+
+
+sample_data = {
+    "node1:gesture=2,pose=1": {
+        "pose": {"throughput": 20},
+        "gesture": {"throughput": 30},
+    },
+    "node1:gesture=1,pose=2": {
+        "pose": {"throughput": 35},
+        "gesture": {"throughput": 20},
+    },
+    "node1:pose=1": {"pose": {"throughput": 50}},
+    "node1:gesture=2": {"gesture": {"throughput": 45}},
+    "node1:gesture=2,pose=2": {
+        "pose": {"throughput": 25},
+        "gesture": {"throughput": 25},
+    },
+    "node2:object=1,pose=1": {
+        "pose": {"throughput": 40},
+        "object": {"throughput": 15},
+    },
+    "node2:gesture=2": {"gesture": {"throughput": 38}},
+    "node1:pose=3": {"pose": {"throughput": 18}},
+}
+
+
+def test_throughput_recorder_nested():
+    async def run():
+        recorder = ThroughputRecorder(initial_data=sample_data)
+        assert await recorder.get("node1:gesture=2,pose=1", "pose") == 20
+        assert await recorder.get("node1:gesture=2", "gesture") == 45
+        await recorder.save("node1:gesture=2,pose=1", 55, "pose")
+        assert await recorder.get("node1:gesture=2,pose=1", "pose") == 55
+        # backwards compatibility with simple values
+        await recorder.save("simple", 99)
+        assert await recorder.get("simple") == 99
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- extend `ThroughputRecorder` to read/write a hierarchical JSON structure
- persist data to disk when a file path is provided
- keep backwards compatibility with existing API
- add unit test verifying nested behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e81e310a8833196d4842fa1b62ddd