### PR TITLE
Add Prometheus service

### DIFF
--- a/event_handler/__init__.py
+++ b/event_handler/__init__.py
@@ -10,6 +10,7 @@ from .services.throughput_recorder import ThroughputRecorder
 from .services.adjustment_coordinator import AdjustmentCoordinator
 from .services.dispatcher import Dispatcher
 from .services.state_manager import StateManager
+from .services.prometheus import PrometheusService
 
 __all__ = [
     "Event",
@@ -24,4 +25,5 @@ __all__ = [
     "AdjustmentCoordinator",
     "Dispatcher",
     "StateManager",
+    "PrometheusService",
 ]

--- a/event_handler/context.py
+++ b/event_handler/context.py
@@ -6,6 +6,7 @@ from .services.throughput_recorder import ThroughputRecorder
 from .services.adjustment_coordinator import AdjustmentCoordinator
 from .services.dispatcher import Dispatcher
 from .services.state_manager import StateManager
+from .services.prometheus import PrometheusService
 
 class Context(NamedTuple):
     repo: Repository
@@ -14,3 +15,4 @@ class Context(NamedTuple):
     adjuster: AdjustmentCoordinator
     dispatcher: Dispatcher
     state: StateManager
+    prometheus: PrometheusService

--- a/event_handler/services/__init__.py
+++ b/event_handler/services/__init__.py
@@ -4,6 +4,7 @@ from .throughput_recorder import ThroughputRecorder
 from .adjustment_coordinator import AdjustmentCoordinator
 from .dispatcher import Dispatcher
 from .state_manager import StateManager, State
+from .prometheus import PrometheusService
 
 __all__ = [
     "Repository",
@@ -13,4 +14,5 @@ __all__ = [
     "Dispatcher",
     "StateManager",
     "State",
+    "PrometheusService",
 ]

--- a/event_handler/services/prometheus.py
+++ b/event_handler/services/prometheus.py
@@ -1,0 +1,20 @@
+import asyncio
+import json
+from urllib import parse, request
+
+
+class PrometheusService:
+    """Simple client for Prometheus HTTP API."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    async def query(self, query: str) -> dict:
+        """Run an instant query and return the JSON response."""
+
+        def _fetch() -> dict:
+            url = f"{self.base_url}/api/v1/query?query={parse.quote(query)}"
+            with request.urlopen(url) as resp:
+                return json.loads(resp.read().decode())
+
+        return await asyncio.to_thread(_fetch)

--- a/tests/test_deployment_change.py
+++ b/tests/test_deployment_change.py
@@ -15,6 +15,7 @@ from event_handler import (
     AdjustmentCoordinator,
     Dispatcher,
     StateManager,
+    PrometheusService,
 )
 
 
@@ -26,8 +27,9 @@ def test_deployment_change_flow():
         adjuster = AdjustmentCoordinator()
         dispatcher = Dispatcher()
         state = StateManager()
+        prometheus = PrometheusService("http://localhost:9090")
 
-        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state)
+        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state, prometheus)
         processor = EventProcessor(ctx)
         processor.register_handler("DEPLOYMENT_CHANGE", DeploymentChangeHandler())
 

--- a/tests/test_high_latency.py
+++ b/tests/test_high_latency.py
@@ -15,6 +15,7 @@ from event_handler import (
     AdjustmentCoordinator,
     Dispatcher,
     StateManager,
+    PrometheusService,
 )
 
 
@@ -33,7 +34,8 @@ def test_high_latency_handler_registration():
         adjuster = AdjustmentCoordinator()
         dispatcher = Dispatcher()
         state = StateManager()
-        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state)
+        prometheus = PrometheusService("http://localhost:9090")
+        ctx = Context(repo, tester, recorder, adjuster, dispatcher, state, prometheus)
         processor = EventProcessor(ctx)
         processor.register_handler("HIGH_LATENCY", CustomHighLatencyHandler())
 

--- a/tests/test_prometheus_service.py
+++ b/tests/test_prometheus_service.py
@@ -1,0 +1,29 @@
+import asyncio
+from unittest.mock import patch
+
+from event_handler.services.prometheus import PrometheusService
+
+
+def test_prometheus_query():
+    async def run():
+        service = PrometheusService("http://localhost:9090")
+
+        def fake_urlopen(url):
+            class Resp:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    pass
+
+                def read(self):
+                    assert url == "http://localhost:9090/api/v1/query?query=up"
+                    return b"{\"status\": \"success\"}"
+
+            return Resp()
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            data = await service.query("up")
+            assert data["status"] == "success"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add PrometheusService with simple HTTP query ability
- expose the new service in package exports and context
- adjust existing tests for new Context parameter
- add unit test for PrometheusService

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea4f4cb588331a3d82706af58821a