### PR TITLE
Refactor into modular core and infra packages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import build_context, create_processor, run
+
+__all__ = ["build_context", "create_processor", "run"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,36 @@
+"""Application entry point assembling dependencies."""
+
+from core import EventProcessor, Context
+from core.domain import Event, StateManager
+from handlers import DeploymentChangeHandler, HighLatencyHandler, IdleSystemHandler
+from infra import (
+    InMemoryRepository,
+    SimplePressureTester,
+    JSONThroughputRepository,
+    InMemoryDispatcher,
+    SimpleAdjustmentStrategy,
+)
+
+
+def build_context() -> Context:
+    repo = InMemoryRepository()
+    tester = SimplePressureTester()
+    recorder = JSONThroughputRepository()
+    adjuster = SimpleAdjustmentStrategy()
+    dispatcher = InMemoryDispatcher()
+    state = StateManager()
+    return Context(repo, tester, recorder, adjuster, dispatcher, state)
+
+
+def create_processor(ctx: Context) -> EventProcessor:
+    processor = EventProcessor(ctx)
+    processor.register_handler("DEPLOYMENT_CHANGE", DeploymentChangeHandler())
+    processor.register_handler("HIGH_LATENCY", HighLatencyHandler())
+    processor.register_handler("IDLE_SYSTEM", IdleSystemHandler())
+    return processor
+
+
+async def run(event: Event) -> None:
+    ctx = build_context()
+    processor = create_processor(ctx)
+    await processor.process(event)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,5 @@
+from .domain import Event, StateManager, State
+from .context import Context
+from .processor import EventProcessor
+
+__all__ = ["Event", "StateManager", "State", "Context", "EventProcessor"]

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,18 @@
+from typing import NamedTuple
+
+from core.services import (
+    Repository,
+    PressureTester,
+    ThroughputRepository,
+    AdjustmentStrategy,
+    Dispatcher,
+)
+from core.domain import StateManager
+
+class Context(NamedTuple):
+    repo: Repository
+    tester: PressureTester
+    recorder: ThroughputRepository
+    adjuster: AdjustmentStrategy
+    dispatcher: Dispatcher
+    state: StateManager

--- a/core/domain/__init__.py
+++ b/core/domain/__init__.py
@@ -1,0 +1,4 @@
+from .event import Event
+from .state_manager import StateManager, State
+
+__all__ = ["Event", "StateManager", "State"]

--- a/core/domain/event.py
+++ b/core/domain/event.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class Event:
+    type: str
+    payload: dict
+    timestamp: datetime
+    source: str

--- a/core/domain/state_manager.py
+++ b/core/domain/state_manager.py
@@ -1,0 +1,22 @@
+import asyncio
+from enum import Enum
+
+class State(Enum):
+    STABLE = "stable"
+    ADJUSTING = "adjusting"
+
+class StateManager:
+    def __init__(self):
+        self.state = State.STABLE
+        self._lock = asyncio.Lock()
+
+    async def try_enter_adjusting(self) -> bool:
+        async with self._lock:
+            if self.state == State.ADJUSTING:
+                return False
+            self.state = State.ADJUSTING
+            return True
+
+    async def exit_adjusting(self) -> None:
+        async with self._lock:
+            self.state = State.STABLE

--- a/core/processor.py
+++ b/core/processor.py
@@ -1,0 +1,26 @@
+from typing import Dict
+
+from core.domain import Event
+from core.context import Context
+from core.domain.state_manager import State
+from handlers.base import BaseHandler
+
+class EventProcessor:
+    def __init__(self, ctx: Context):
+        self.ctx = ctx
+        self.handlers: Dict[str, BaseHandler] = {}
+
+    def register_handler(self, event_type: str, handler: BaseHandler) -> None:
+        self.handlers[event_type] = handler
+
+    async def process(self, event: Event) -> None:
+        handler = self.handlers.get(event.type)
+        if not handler:
+            return
+        entered = await self.ctx.state.try_enter_adjusting()
+        if not entered:
+            return
+        try:
+            await handler.handle(event, self.ctx)
+        finally:
+            await self.ctx.state.exit_adjusting()

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,0 +1,14 @@
+from .adjustment_strategy import AdjustmentStrategy
+from .dispatcher import Dispatcher
+from .pressure_tester import PressureTester
+from .throughput_repository import ThroughputRepository
+
+__all__ = [
+    "AdjustmentStrategy",
+    "Dispatcher",
+    "PressureTester",
+    "ThroughputRepository",
+]
+from .repository import Repository
+
+__all__.append("Repository")

--- a/core/services/adjustment_strategy.py
+++ b/core/services/adjustment_strategy.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+class AdjustmentStrategy(ABC):
+    """Compute new request frequency based on throughput."""
+
+    @abstractmethod
+    async def compute_frequency(self, throughput: int) -> int:
+        """Return a request frequency derived from throughput."""
+        raise NotImplementedError

--- a/core/services/dispatcher.py
+++ b/core/services/dispatcher.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+class Dispatcher(ABC):
+    """Send commands to external agents."""
+
+    @abstractmethod
+    async def dispatch(self, frequency: int) -> None:
+        """Dispatch the new frequency value."""
+        raise NotImplementedError

--- a/core/services/pressure_tester.py
+++ b/core/services/pressure_tester.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+class PressureTester(ABC):
+    """Interface for performing load tests."""
+
+    @abstractmethod
+    async def load_test(self, deployment_hash: str) -> int:
+        """Return measured throughput for the deployment."""
+        raise NotImplementedError

--- a/core/services/repository.py
+++ b/core/services/repository.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+class Repository(ABC):
+    @abstractmethod
+    async def get(self, key: Any):
+        raise NotImplementedError
+
+    @abstractmethod
+    async def set(self, key: Any, value: Any) -> None:
+        raise NotImplementedError

--- a/core/services/throughput_repository.py
+++ b/core/services/throughput_repository.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Mapping, Union, Any
+
+class ThroughputRepository(ABC):
+    """Persist and retrieve throughput values."""
+
+    @abstractmethod
+    async def get(self, key: Union[str, Mapping[str, Any]], category: Optional[str] = None) -> Optional[int]:
+        """Retrieve stored throughput."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def save(self, key: Union[str, Mapping[str, Any]], throughput: int, category: Optional[str] = None) -> None:
+        """Persist throughput information."""
+        raise NotImplementedError

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,9 @@
+from .deployment_change import DeploymentChangeHandler
+from .high_latency import HighLatencyHandler
+from .idle_system import IdleSystemHandler
+
+__all__ = [
+    "DeploymentChangeHandler",
+    "HighLatencyHandler",
+    "IdleSystemHandler",
+]

--- a/handlers/base.py
+++ b/handlers/base.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+from core.domain import Event
+from core.context import Context
+
+class BaseHandler(ABC):
+    @abstractmethod
+    async def handle(self, event: Event, ctx: Context) -> None:
+        """Process an event."""
+        raise NotImplementedError

--- a/handlers/deployment_change.py
+++ b/handlers/deployment_change.py
@@ -1,0 +1,25 @@
+import logging
+
+from core.domain import Event
+from core.context import Context
+from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+class DeploymentChangeHandler(BaseHandler):
+    async def handle(self, event: Event, ctx: Context) -> None:
+        deployment_hash = event.payload.get("hash")
+        logger.info("Deployment change event received: %s", deployment_hash)
+        if deployment_hash is None:
+            logger.info("No deployment hash provided")
+            return
+        throughput = await ctx.recorder.get(deployment_hash)
+        logger.info("Throughput lookup result: %s", throughput)
+        if throughput is None:
+            logger.info("Running load test for %s", deployment_hash)
+            throughput = await ctx.tester.load_test(deployment_hash)
+            await ctx.recorder.save(deployment_hash, throughput)
+            logger.info("Recorded throughput %s", throughput)
+        frequency = await ctx.adjuster.compute_frequency(throughput)
+        await ctx.dispatcher.dispatch(frequency)
+        logger.info("Dispatched frequency %s", frequency)

--- a/handlers/high_latency.py
+++ b/handlers/high_latency.py
@@ -1,0 +1,14 @@
+import logging
+
+from core.domain import Event
+from core.context import Context
+from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+class HighLatencyHandler(BaseHandler):
+    """Handle high latency events."""
+
+    async def handle(self, event: Event, ctx: Context) -> None:
+        logger.info("High latency event received: %s", event.payload)
+        logger.info("No action taken in stub handler")

--- a/handlers/idle_system.py
+++ b/handlers/idle_system.py
@@ -1,0 +1,14 @@
+import logging
+
+from core.domain import Event
+from core.context import Context
+from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+class IdleSystemHandler(BaseHandler):
+    """Handle idle system events."""
+
+    async def handle(self, event: Event, ctx: Context) -> None:
+        logger.info("Idle system event received: %s", event.payload)
+        logger.info("No action taken in stub handler")

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,0 +1,13 @@
+from .repository import InMemoryRepository
+from .pressure_tester import SimplePressureTester
+from .throughput_repository import JSONThroughputRepository
+from .dispatcher import InMemoryDispatcher
+from .adjustment_strategy import SimpleAdjustmentStrategy
+
+__all__ = [
+    "InMemoryRepository",
+    "SimplePressureTester",
+    "JSONThroughputRepository",
+    "InMemoryDispatcher",
+    "SimpleAdjustmentStrategy",
+]

--- a/infra/adjustment_strategy.py
+++ b/infra/adjustment_strategy.py
@@ -1,0 +1,7 @@
+from core.services import AdjustmentStrategy
+
+class SimpleAdjustmentStrategy(AdjustmentStrategy):
+    """Compute new request frequency."""
+
+    async def compute_frequency(self, throughput: int) -> int:
+        return throughput

--- a/infra/dispatcher.py
+++ b/infra/dispatcher.py
@@ -1,0 +1,10 @@
+from core.services import Dispatcher as DispatcherInterface
+
+class InMemoryDispatcher(DispatcherInterface):
+    """Store dispatched frequency for inspection in tests."""
+
+    def __init__(self) -> None:
+        self.last_dispatched = None
+
+    async def dispatch(self, frequency: int) -> None:
+        self.last_dispatched = frequency

--- a/infra/pressure_tester.py
+++ b/infra/pressure_tester.py
@@ -1,0 +1,7 @@
+from core.services import PressureTester
+
+class SimplePressureTester(PressureTester):
+    """Stub that 'measures' throughput."""
+
+    async def load_test(self, deployment_hash: str) -> int:
+        return 100

--- a/infra/repository.py
+++ b/infra/repository.py
@@ -1,0 +1,11 @@
+class InMemoryRepository:
+    """Simple in-memory repository placeholder."""
+
+    def __init__(self) -> None:
+        self.storage = {}
+
+    async def get(self, key):
+        return self.storage.get(key)
+
+    async def set(self, key, value):
+        self.storage[key] = value

--- a/infra/throughput_repository.py
+++ b/infra/throughput_repository.py
@@ -1,0 +1,72 @@
+"""Concrete throughput repository using optional JSON persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Union, Mapping
+
+from core.services import ThroughputRepository
+from utils.helpers import ThroughputKey
+
+
+class JSONThroughputRepository(ThroughputRepository):
+    """Persist throughput values in memory with optional JSON file."""
+
+    def __init__(self, *, initial_data: Optional[Dict[str, Any]] = None, file_path: Optional[str] = None) -> None:
+        self._values: Dict[str, Any] = initial_data.copy() if initial_data else {}
+        self._path: Optional[Path] = Path(file_path) if file_path else None
+        if self._path and self._path.exists():
+            try:
+                loaded = json.loads(self._path.read_text())
+                if isinstance(loaded, dict):
+                    self._values.update(loaded)
+            except json.JSONDecodeError:
+                pass
+
+    @staticmethod
+    def make_key(node_name: str, service_counts: Dict[str, int]) -> str:
+        return ThroughputKey(node_name, service_counts).to_string()
+
+    def _normalize_key(self, key: Union[str, Mapping[str, Any], ThroughputKey]) -> str:
+        if isinstance(key, ThroughputKey):
+            key = key.to_string()
+        elif isinstance(key, Mapping):
+            key = self.make_key(key.get("node"), dict(key.get("services", {})))
+        if ":" not in key:
+            return key
+        prefix, rest = key.split(":", 1)
+        parts = [p for p in rest.split(",") if p]
+        if not parts:
+            return prefix
+        return f"{prefix}:{','.join(sorted(parts))}"
+
+    async def get(self, key: Union[str, Mapping[str, Any], ThroughputKey], category: Optional[str] = None) -> Optional[int]:
+        key = self._normalize_key(key)
+        value = self._values.get(key)
+        if category is None:
+            if isinstance(value, dict) and len(value) == 1:
+                inner = next(iter(value.values()))
+                return inner.get("throughput") if isinstance(inner, dict) else None
+            return value if not isinstance(value, dict) else None
+        if isinstance(value, dict):
+            inner = value.get(category)
+            return inner.get("throughput") if isinstance(inner, dict) else None
+        return None
+
+    async def save(self, key: Union[str, Mapping[str, Any], ThroughputKey], throughput: int, category: Optional[str] = None) -> None:
+        key = self._normalize_key(key)
+        if category is None:
+            self._values[key] = throughput
+        else:
+            bucket = self._values.setdefault(key, {})
+            if not isinstance(bucket, dict):
+                bucket = {}
+                self._values[key] = bucket
+            entry = bucket.setdefault(category, {})
+            if not isinstance(entry, dict):
+                entry = {}
+                bucket[category] = entry
+            entry["throughput"] = throughput
+        if self._path:
+            self._path.write_text(json.dumps(self._values, indent=2))

--- a/tests/test_high_latency.py
+++ b/tests/test_high_latency.py
@@ -4,18 +4,16 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
-from event_handler import (
-    Event,
-    Context,
-    EventProcessor,
-    HighLatencyHandler,
-    Repository,
-    PressureTester,
-    ThroughputRecorder,
-    AdjustmentCoordinator,
-    Dispatcher,
-    StateManager,
+from core import Event, Context, EventProcessor
+from handlers import HighLatencyHandler
+from infra import (
+    InMemoryRepository,
+    SimplePressureTester,
+    JSONThroughputRepository,
+    SimpleAdjustmentStrategy,
+    InMemoryDispatcher,
 )
+from core.domain import StateManager
 
 
 def test_high_latency_handler_registration():
@@ -27,11 +25,11 @@ def test_high_latency_handler_registration():
             called = True
 
     async def run():
-        repo = Repository()
-        tester = PressureTester()
-        recorder = ThroughputRecorder()
-        adjuster = AdjustmentCoordinator()
-        dispatcher = Dispatcher()
+        repo = InMemoryRepository()
+        tester = SimplePressureTester()
+        recorder = JSONThroughputRepository()
+        adjuster = SimpleAdjustmentStrategy()
+        dispatcher = InMemoryDispatcher()
         state = StateManager()
         ctx = Context(repo, tester, recorder, adjuster, dispatcher, state)
         processor = EventProcessor(ctx)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+from .helpers import ThroughputKey
+
+__all__ = ["ThroughputKey"]

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class ThroughputKey:
+    """Structured identifier for throughput entries."""
+
+    node_name: str
+    service_counts: Dict[str, int]
+
+    def to_string(self) -> str:
+        sorted_services = sorted(
+            (svc, cnt) for svc, cnt in self.service_counts.items() if cnt > 0
+        )
+        if not sorted_services:
+            return self.node_name
+        parts = [f"{svc}={cnt}" for svc, cnt in sorted_services]
+        return f"{self.node_name}:{','.join(parts)}"


### PR DESCRIPTION
## Summary
- add new `core` package with domain models, service interfaces, processor and context
- split event handlers into new `handlers` package
- add `infra` implementations for repositories, testing and dispatching
- provide helper utilities and application entry point
- update tests to use the new module paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707c59a9388331a15fcd93e1124834