### PR TITLE
feat: add Kopf operator for event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Event Handler
 
-This repository provides a minimal implementation of an event processing center as described in the software requirements specification.  
+This repository provides a minimal implementation of an event processing center as described in the software requirements specification.
 The `EventProcessor` routes incoming events to registered handlers while coordinating supporting services.  Only a `DeploymentChangeHandler` is included as an example.
 
 ## Throughput keys
@@ -14,6 +14,38 @@ await recorder.save(deployment, 100, "pose")
 ```
 The dictionary is converted internally to the canonical key so lookups are
 order independent.
+
+## Kopf operator
+
+[Kopf](https://kopf.readthedocs.io/) can be used to trigger domain events from
+Kubernetes.  The operator defined in `infra/kopf_operator.py` listens for
+custom resources of kind `Event` in group `example.com` and forwards them to
+the domain `EventProcessor`.
+
+Run the operator:
+
+```bash
+pip install kopf
+kopf run infra/kopf_operator.py
+```
+
+Creating a custom resource with fields `spec.type` and `spec.payload` will
+create a domain event with those values and process it with all registered
+handlers.
+
+### Extending
+
+Handlers remain decoupled from the operator.  To add a new event type:
+
+```python
+from handlers.base import BaseHandler
+
+class ScaleUpHandler(BaseHandler):
+    async def handle(self, event, ctx):
+        ...
+
+processor.register_handler("SCALE_UP", ScaleUpHandler())
+```
 
 ## Running tests
 

--- a/infra/kopf_operator.py
+++ b/infra/kopf_operator.py
@@ -1,0 +1,40 @@
+"""Kopf-based operator that feeds Kubernetes events into the domain event processor."""
+
+from datetime import datetime
+from typing import Any
+
+import kopf
+
+from app.main import build_context, create_processor
+from core.domain import Event
+
+
+class KopfEventBridge:
+    """Bridge translating Kopf callbacks into domain events.
+
+    The bridge keeps the event processing logic isolated from Kopf so the
+    infrastructure layer can be replaced or extended without touching the
+    domain code.  This maintains high cohesion and low coupling in line with
+    DDD principles.
+    """
+
+    def __init__(self) -> None:
+        self._processor = create_processor(build_context())
+
+    async def forward(self, spec: dict[str, Any]) -> None:
+        event = Event(
+            type=spec.get("type"),
+            payload=spec.get("payload", {}),
+            timestamp=datetime.utcnow(),
+            source="kopf",
+        )
+        await self._processor.process(event)
+
+
+_bridge = KopfEventBridge()
+
+
+@kopf.on.event("example.com", "v1", "events")
+async def handle_kopf_event(spec, **_: Any) -> None:
+    """Receive custom resources and forward them to the event processor."""
+    await _bridge.forward(spec)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+kopf
+pytest


### PR DESCRIPTION
## Summary
- add Kopf-based operator to dispatch Kubernetes events to the EventProcessor
- document how to run the operator and extend handlers
- add requirements file listing runtime and test dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895cf3ae6648331891dc8b2bb1ed956